### PR TITLE
Add georec, mxv, radrec, spkezr, vcrss, vdot, xpose

### DIFF
--- a/rust-spice/src/core/mod.rs
+++ b/rust-spice/src/core/mod.rs
@@ -39,6 +39,7 @@ CSPICE | **rust-spice** | Description
 [furnsh_c][furnsh_c link] | [`raw::furnsh`] | Furnish a program with SPICE kernels
 [gcpool_c][gcpool_c link] | *TODO*
 [gdpool_c][gdpool_c link] | *TODO*
+[georec_c][georec_c link] | [`raw::georec`] |  Geodetic to rectangular coordinates
 [getfov_c][getfov_c link] | *TODO*
 [gipool_c][gipool_c link] | *TODO*
 [illumf_c][illumf_c link] | [`raw::illumf`] | Illumination angles, general source, return flags
@@ -47,6 +48,7 @@ CSPICE | **rust-spice** | Description
 [ktotal_c][ktotal_c link] | [`raw::ktotal`] | Kernel Totals
 [latrec_c][latrec_c link] | [`raw::latrec`] | Latitudinal to rectangular coordinates
 [latsrf_c][latsrf_c link] | *TODO*
+[mxv_c][mxv_c link] | [`raw::mxv`] |  Matrix times vector, 3x3
 [occult_c][occult_c link] | [`raw::occult`] | Find occultation type at time
 [pckcov_c][pckcov_c link] | *TODO*
 [pxform_c][pxform_c link] | [`raw::pxform`] | Position Transformation Matrix
@@ -62,7 +64,7 @@ CSPICE | **rust-spice** | Description
 [spkcpt_c][spkcpt_c link] | *TODO*
 [spkcvo_c][spkcvo_c link] | *TODO*
 [spkcvt_c][spkcvt_c link] | *TODO*
-[spkezr_c][spkezr_c link] | *TODO*
+[spkezr_c][spkezr_c link] | [`raw::spkezr`] | S/P Kernel, easier reader
 [spkobj_c][spkobj_c link] | *TODO*
 [spkpos_c][spkpos_c link] | [`raw::spkpos`] | S/P Kernel, position
 [srfc2s_c][srfc2s_c link] | *TODO*
@@ -72,10 +74,14 @@ CSPICE | **rust-spice** | Description
 [srfscc_c][srfscc_c link] | *TODO*
 [str2et_c][str2et_c link] | [`raw::str2et`] | String to ET
 [sxform_c][sxform_c link] | *TODO*
+[radrec_c][radrec_c link] | [`raw::radrec`] |  RA and DEC to rectangular coordinates
 [recrad_c][recrad_c link] | [`raw::recrad`] | Rectangular coordinates to RA and DEC
 [timout_c][timout_c link] | [`neat::timout`] | Time Output
 [unload_c][unload_c link] | [`raw::unload`] | Unload a kernel
+[vcrss_c][vcrss_c link] | [`raw::vcrss`] | Vector cross product, 3 dimensions
+[vdot_c][vdot_c link] | [`raw::vdot`] |  Vector dot product, 3 dimensions
 [vsep_c][vsep_c link] | [`raw::vsep`] | Angular separation of vectors, 3 dimensions
+[xpose_c][xpose_c link] | [`raw::xpose`] | Transpose a matrix, 3x3
 
 [bodc2n_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/bodc2n_c.html
 [bodfnd_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/bodfnd_c.html
@@ -100,6 +106,7 @@ CSPICE | **rust-spice** | Description
 [gcpool_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/gcpool_c.html
 [gdpool_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/gdpool_c.html
 [getfov_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/getfov_c.html
+[georec_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/georec_c.html
 [gipool_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/gipool_c.html
 [illumf_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/illumf_c.html
 [kclear_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/kclear_c.html
@@ -107,6 +114,7 @@ CSPICE | **rust-spice** | Description
 [ktotal_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/ktotal_c.html
 [latrec_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/latrec_c.html
 [latsrf_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/latsrf_c.html
+[mxv_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/mxv_c.html
 [occult_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/occult_c.html
 [pxform_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/pxform_c.html
 [pckcov_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/pckcov_c.html
@@ -133,10 +141,14 @@ CSPICE | **rust-spice** | Description
 [srfscc_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/srfscc_c.html
 [str2et_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/str2et_c.html
 [sxform_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/sxform_c.html
+[radrec_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/radrec_c.html
 [recrad_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/recrad_c.html
 [timout_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/timout_c.html
 [unload_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/unload_c.html
+[vcrss_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/vcrss_c.html
+[vdot_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/vdot_c.html
 [vsep_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/vsep_c.html
+[xpose_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/xpose_c.html
 */
 
 pub mod neat;
@@ -144,8 +156,9 @@ pub mod raw;
 
 pub use self::neat::{bodc2n, dskp02, dskv02, kdata, timout};
 pub use self::raw::{
-    bodn2c, dascls, dasopr, dlabfs, dskgd, dskn02, dskobj, dskx02, dskz02, furnsh, illumf, kclear,
-    ktotal, latrec, pxform, pxfrm2, recrad, spkpos, str2et, unload, vsep, Cell, DLADSC, DSKDSC,
+    bodn2c, dascls, dasopr, dlabfs, dskgd, dskn02, dskobj, dskx02, dskz02, furnsh, georec, illumf,
+    kclear, ktotal, latrec, mxv, pxform, pxfrm2, radrec, recrad, spkezr, spkpos, str2et, unload,
+    vcrss, vdot, vsep, xpose, DLADSC, DSKDSC,
 };
 
 /**

--- a/rust-spice/src/core/neat.rs
+++ b/rust-spice/src/core/neat.rs
@@ -4,7 +4,7 @@ Improvement on the procedurally generated functions.
 ## Description
 
 The idiomatic Rust bindings to CSPICE can be very hard to generate in a procedural macro in some
-specific cases. You can find, in this module, fonctions wrapped from [`raw`] to better match
+specific cases. You can find, in this module, functions wrapped from [`raw`] to better match
 an idiomatic usage. The improvements consists in functions:
 
 + taking a string as input in C requires to also send the size of the pointer to a char array. In Rust, you

--- a/rust-spice/src/core/raw.rs
+++ b/rust-spice/src/core/raw.rs
@@ -179,6 +179,13 @@ cspice_proc!(
 
 cspice_proc!(
     /**
+    Convert geodetic coordinates to rectangular coordinates.
+     */
+    pub fn georec(lon: f64, lat: f64, alt: f64, re: f64, f: f64) -> [f64; 3] {}
+);
+
+cspice_proc!(
+    /**
     Compute the illumination angles---phase, incidence, and emission---at a specified point on a
     target body. Return logical flags indicating whether the surface point is visible from the
     observer's position and whether the surface point is illuminated.
@@ -274,6 +281,13 @@ cspice_proc!(
 
 cspice_proc!(
     /**
+       Multiply a 3x3 double precision matrix with a 3-dimensional double precision vector.
+    */
+    pub fn mxv(m1: [[f64; 3]; 3], vin: [f64; 3]) -> [f64; 3] {}
+);
+
+cspice_proc!(
+    /**
     Determines the occultation condition (not occulted, partially, etc.) of one target relative to
     another target as seen by an observer at a given time, with targets modeled as points,
     ellipsoids, or digital shapes (DSK)
@@ -311,6 +325,13 @@ cspice_proc!(
 
 cspice_proc!(
     /**
+    Convert range, right ascension, and declination to rectangular coordinates
+     */
+    pub fn radrec(range: f64, ra: f64, dec: f64) -> [f64; 3] {}
+);
+
+cspice_proc!(
+    /**
     Convert rectangular coordinates to range, right ascension, and declination.
     */
     pub fn recrad(rectan: [f64; 3]) -> (f64, f64, f64) {}
@@ -322,6 +343,15 @@ cspice_proc!(
     light time (planetary aberration) and stellar aberration.
     */
     pub fn spkpos(targ: &str, et: f64, frame: &str, abcorr: &str, obs: &str) -> ([f64; 3], f64) {}
+);
+
+cspice_proc!(
+    /**
+      Return the state (position and velocity) of a target body
+      relative to an observing body, optionally corrected for light
+      time (planetary aberration) and stellar aberration.
+    */
+    pub fn spkezr(targ: &str, et: f64, frame: &str, abcorr: &str, obs: &str) -> ([f64; 6], f64) {}
 );
 
 cspice_proc!(
@@ -360,4 +390,26 @@ cspice_proc!(
     */
     #[return_output]
     pub fn vsep(v1: [f64; 3], v2: [f64; 3]) -> f64 {}
+);
+
+cspice_proc!(
+    /**
+    Compute the dot product of two double precision, 3-dimensional vectors.
+     */
+    #[return_output]
+    pub fn vdot(v1: [f64; 3], v2: [f64; 3]) -> f64 {}
+);
+
+cspice_proc!(
+    /**
+    Compute the cross product of two 3-dimensional vectors.
+     */
+    pub fn vcrss(v1: [f64; 3], v2: [f64; 3]) -> [f64; 3] {}
+);
+
+cspice_proc!(
+    /**
+    Transpose a 3x3 matrix.
+     */
+    pub fn xpose(m1: [[f64; 3]; 3]) -> [[f64; 3]; 3] {}
 );

--- a/rust-spice/tests/core/mod.rs
+++ b/rust-spice/tests/core/mod.rs
@@ -51,6 +51,43 @@ fn dskp02() {
 
 #[test]
 #[serial]
+fn georec() {
+    // Test vectors are from https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/georec_c.html
+    // Based on the Clark66 spheroid
+    const CLARK66_RADIUS: f64 = 6378.2064;
+    const CLARK66_FLATTENING: f64 = 1.0 / 294.9787;
+
+    // lon, lat, alt  -> x, y, z
+    let test_data: [[f64; 6]; 11] = [
+        [0.0000, 90.0000, -6356.5838, 0.0000, 0.0000, 0.0000],
+        [0.0000, 0.0000, -6377.2063, 1.0000, 0.0000, 0.0000],
+        [90.0000, 0.0000, -6377.2063, 0.0000, 1.0000, 0.0000],
+        [0.0000, 90.0000, -6355.5838, 0.0000, 0.0000, 1.0000],
+        [180.0000, 0.0000, -6377.2063, -1.0000, 0.0000, 0.0000],
+        [-90.0000, 0.0000, -6377.2063, 0.0000, -1.0000, 0.0000],
+        [0.0000, -90.0000, -6355.5838, 0.0000, 0.0000, -1.0000],
+        [45.0000, 0.0000, -6376.7921, 1.0000, 1.0000, 0.0000],
+        [0.0000, 88.7070, -6355.5725, 1.0000, 0.0000, 1.0000],
+        [90.0000, 88.7070, -6355.5725, 0.0000, 1.0000, 1.0000],
+        [45.0000, 88.1713, -6355.5612, 1.0000, 1.0000, 1.0000],
+    ];
+
+    for test in test_data.iter() {
+        let rect = spice::georec(
+            test[0].to_radians(),
+            test[1].to_radians(),
+            test[2],
+            CLARK66_RADIUS,
+            CLARK66_FLATTENING,
+        );
+        assert_relative_eq!(rect[0], test[3], epsilon = 0.0001);
+        assert_relative_eq!(rect[1], test[4], epsilon = 0.0001);
+        assert_relative_eq!(rect[2], test[5], epsilon = 0.0001);
+    }
+}
+
+#[test]
+#[serial]
 fn pxform() {
     spice::furnsh("rsc/krn/hera_study_PO_EMA_2024.tm");
 
@@ -88,6 +125,62 @@ fn pxfrm2() {
             assert_relative_eq!(component, expected_component, epsilon = f64::EPSILON);
         }
     }
+
+    spice::unload("rsc/krn/hera_study_PO_EMA_2024.tm");
+}
+
+#[test]
+#[serial]
+fn radec() {
+    spice::furnsh("rsc/krn/hera_study_PO_EMA_2024.tm");
+
+    // Mirfak J2000 RA and DEC
+    let ra = 51.080_f64.to_radians();
+    let dec = 49.861_f64.to_radians();
+
+    // Convert to Rectangular Coordinates
+    let j2000_rect = spice::radrec(1.0, ra, dec);
+
+    // Generate the position vectors to translate from J2000 to B1950
+    let mat = spice::pxform("J2000", "B1950", 0.0);
+
+    // Perform the conversion
+    let b1950_rect = spice::mxv(mat, j2000_rect);
+
+    // Translate back to RA and DEC
+    let (_, ra, dec) = spice::recrad(b1950_rect);
+
+    // Expected B1950 RA and DEC
+    let ra_b1950 = 50.185_f64;
+    let dec_b1950 = 49.684_f64;
+
+    // Compare to 3 decimal places
+    assert_relative_eq!(ra.to_degrees(), ra_b1950, epsilon = 0.001);
+    assert_relative_eq!(dec.to_degrees(), dec_b1950, epsilon = 0.001);
+
+    spice::unload("rsc/krn/hera_study_PO_EMA_2024.tm");
+}
+
+#[test]
+#[serial]
+fn spkezr() {
+    spice::furnsh("rsc/krn/hera_study_PO_EMA_2024.tm");
+
+    // an arbitrary time
+    let et = spice::str2et("2021-01-06 09:36:09.1825432 TDB");
+
+    // sun in relation to ssb
+    let (sun_ssb_posvec, _sun_ssb_lt) = spice::spkezr("sun", et, "j2000", "none", "ssb");
+    // earth in relation to ssb
+    let (earth_ssb_posvec, _earth_ssb_lt) = spice::spkezr("earth", et, "j2000", "none", "ssb");
+    // earth in relation to sun
+    let (earth_sun_posvec, _earth_sun_ly) = spice::spkezr("earth", et, "j2000", "none", "sun");
+
+    // Quick check that the (Sun relative) earth velocity vectors are the same regardless of whether we
+    // calculate them indirectly from SB or directly compared to  the Sun
+    assert_eq!(earth_ssb_posvec[3] - sun_ssb_posvec[3], earth_sun_posvec[3]);
+    assert_eq!(earth_ssb_posvec[4] - sun_ssb_posvec[4], earth_sun_posvec[4]);
+    assert_eq!(earth_ssb_posvec[5] - sun_ssb_posvec[5], earth_sun_posvec[5]);
 
     spice::unload("rsc/krn/hera_study_PO_EMA_2024.tm");
 }
@@ -136,6 +229,26 @@ fn timout() {
     assert_eq!(date, "2027-MAR-23 16:00:00");
 
     spice::unload("rsc/krn/hera_study_PO_EMA_2024.tm");
+}
+
+#[test]
+#[serial]
+fn vdot() {
+    assert_eq!(spice::vdot([1.0, 2.0, 3.0], [1.0, 2.0, 3.0]), 14.0)
+}
+
+#[test]
+#[serial]
+fn vcrss() {
+    // Examples from https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/vcrss_c.html
+    assert_eq!(
+        spice::vcrss([0.0, 1.0, 0.0], [1.0, 0.0, 0.0]),
+        [0.0, 0.0, -1.0]
+    );
+    assert_eq!(
+        spice::vcrss([5.0, 5.0, 5.0], [-1.0, -1.0, -1.0]),
+        [0.0, 0.0, 0.0]
+    );
 }
 
 #[test]


### PR DESCRIPTION
As requested, this is now based on `dev` instead of `main`

Note: The `dev` branch contains a few tests (like `kdata()`) which directly reference `/home/greg/doc/krn/hera/mk/hera_study_PO_EMA_2024.tm` so I wasn't able to run those specific tests as-is.