### PR TITLE
Add spkopn, spkw09, spkcls

### DIFF
--- a/rust-spice-derive/src/lib.rs
+++ b/rust-spice-derive/src/lib.rs
@@ -247,7 +247,8 @@ pub fn cspice_proc(input: TokenStream) -> TokenStream {
                             "str" => pat_macro("crate::cstr", &format!("{}.to_string()", ident)),
                             _ => panic!("->2"),
                         },
-                        _ => panic!("->3"),
+                        Type::Slice(_) => new_pat(format!("{}.as_mut_ptr()", ident)),
+                        _ => panic!("->3")
                     },
                     Type::Array(_) => new_pat(format!("{}.as_mut_ptr()", ident)),
                     _ => panic!("->4"),

--- a/rust-spice-derive/src/lib.rs
+++ b/rust-spice-derive/src/lib.rs
@@ -248,7 +248,7 @@ pub fn cspice_proc(input: TokenStream) -> TokenStream {
                             _ => panic!("->2"),
                         },
                         Type::Slice(_) => new_pat(format!("{}.as_mut_ptr()", ident)),
-                        _ => panic!("->3")
+                        _ => panic!("->3"),
                     },
                     Type::Array(_) => new_pat(format!("{}.as_mut_ptr()", ident)),
                     _ => panic!("->4"),

--- a/rust-spice/src/core/mod.rs
+++ b/rust-spice/src/core/mod.rs
@@ -59,6 +59,7 @@ CSPICE | **rust-spice** | Description
 [scdecd_c][scdecd_c link] | *TODO*
 [scs2e_c][scs2e_c link] | *TODO*
 [sct2e_c][sct2e_c link] | *TODO*
+[spkcls_c][spkcov_c link] | [`raw::spkcls`] | SPK, Close file
 [spkcov_c][spkcov_c link] | *TODO*
 [spkcpo_c][spkcpo_c link] | *TODO*
 [spkcpt_c][spkcpt_c link] | *TODO*
@@ -66,7 +67,9 @@ CSPICE | **rust-spice** | Description
 [spkcvt_c][spkcvt_c link] | *TODO*
 [spkezr_c][spkezr_c link] | [`raw::spkezr`] | S/P Kernel, easier reader
 [spkobj_c][spkobj_c link] | *TODO*
+[spkopn_c][spkopn_c link] | [`raw::spkopn`] | SPK, open new file.
 [spkpos_c][spkpos_c link] | [`raw::spkpos`] | S/P Kernel, position
+[spkw09_c][spkopn_c link] | [`raw::spkw09`] | Write SPK segment, type 9
 [srfc2s_c][srfc2s_c link] | *TODO*
 [srfcss_c][srfcss_c link] | *TODO*
 [srfnrm_c][srfnrm_c link] | *TODO*
@@ -126,6 +129,7 @@ CSPICE | **rust-spice** | Description
 [scencd_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/scencd_c.html
 [scs2e_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/scs2e_c.html
 [sct2e_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/sct2e_c.html
+[spkcls_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/spkcls_c.html
 [spkcpo_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/spkcpo_c.html
 [spkcov_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/spkcov_c.html
 [spkcpt_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/spkcpt_c.html
@@ -133,7 +137,9 @@ CSPICE | **rust-spice** | Description
 [spkcvt_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/spkcvt_c.html
 [spkezr_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/spkezr_c.html
 [spkobj_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/spkobj_c.html
+[spkopn_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/spkopn_c.html
 [spkpos_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/spkpos_c.html
+[spkw09_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/spkw09_c.html
 [srfc2s_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/srfc2s_c.html
 [srfcss_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/srfcss_c.html
 [srfnrm_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/srfnrm_c.html

--- a/rust-spice/src/core/mod.rs
+++ b/rust-spice/src/core/mod.rs
@@ -157,8 +157,8 @@ pub mod raw;
 pub use self::neat::{bodc2n, dskp02, dskv02, kdata, timout};
 pub use self::raw::{
     bodfnd, bodn2c, dascls, dasopr, dlabfs, dskgd, dskn02, dskobj, dskx02, dskz02, furnsh, georec,
-    illumf, kclear, ktotal, latrec, mxv, pxform, pxfrm2, radrec, recrad, spkezr, spkopn, spkpos,
-    spkw09, str2et, unload, vcrss, vdot, vsep, xpose, DLADSC, DSKDSC,
+    illumf, kclear, ktotal, latrec, mxv, pxform, pxfrm2, radrec, recrad, spkcls, spkezr, spkopn,
+    spkpos, spkw09, str2et, unload, vcrss, vdot, vsep, xpose, DLADSC, DSKDSC,
 };
 
 /**

--- a/rust-spice/src/core/mod.rs
+++ b/rust-spice/src/core/mod.rs
@@ -157,8 +157,8 @@ pub mod raw;
 pub use self::neat::{bodc2n, dskp02, dskv02, kdata, timout};
 pub use self::raw::{
     bodfnd, bodn2c, dascls, dasopr, dlabfs, dskgd, dskn02, dskobj, dskx02, dskz02, furnsh, georec,
-    illumf, kclear, ktotal, latrec, mxv, pxform, pxfrm2, radrec, recrad, spkezr, spkpos, str2et,
-    unload, vcrss, vdot, vsep, xpose, DLADSC, DSKDSC,
+    illumf, kclear, ktotal, latrec, mxv, pxform, pxfrm2, radrec, recrad, spkezr, spkopn, spkpos,
+    str2et, unload, vcrss, vdot, vsep, xpose, DLADSC, DSKDSC,
 };
 
 /**

--- a/rust-spice/src/core/mod.rs
+++ b/rust-spice/src/core/mod.rs
@@ -158,7 +158,7 @@ pub use self::neat::{bodc2n, dskp02, dskv02, kdata, timout};
 pub use self::raw::{
     bodfnd, bodn2c, dascls, dasopr, dlabfs, dskgd, dskn02, dskobj, dskx02, dskz02, furnsh, georec,
     illumf, kclear, ktotal, latrec, mxv, pxform, pxfrm2, radrec, recrad, spkezr, spkopn, spkpos,
-    str2et, unload, vcrss, vdot, vsep, xpose, DLADSC, DSKDSC,
+    spkw09, str2et, unload, vcrss, vdot, vsep, xpose, DLADSC, DSKDSC,
 };
 
 /**

--- a/rust-spice/src/core/raw.rs
+++ b/rust-spice/src/core/raw.rs
@@ -354,6 +354,13 @@ cspice_proc! {
 
 cspice_proc! {
     /**
+    Write a type 9 segment to an SPK file.
+     */
+    pub fn spkw09(handle: i32, body: i32, center: i32, frame: &str, first: f64, last: f64, segid: &str, degree: i32, n: i32, states: &mut [[f64; 6]], epochs: &mut [f64]) {}
+}
+
+cspice_proc! {
+    /**
     Return the position of a target body relative to an observing body, optionally corrected for
     light time (planetary aberration) and stellar aberration.
     */

--- a/rust-spice/src/core/raw.rs
+++ b/rust-spice/src/core/raw.rs
@@ -363,6 +363,7 @@ cspice_proc! {
     /**
     Write a type 9 segment to an SPK file.
      */
+    #[allow(clippy::too_many_arguments)]
     pub fn spkw09(handle: i32, body: i32, center: i32, frame: &str, first: f64, last: f64, segid: &str, degree: i32, n: i32, states: &mut [[f64; 6]], epochs: &mut [f64]) {}
 }
 

--- a/rust-spice/src/core/raw.rs
+++ b/rust-spice/src/core/raw.rs
@@ -347,6 +347,13 @@ cspice_proc! {
 
 cspice_proc! {
     /**
+    Create a new SPK file, returning the handle of the opened file
+     */
+    pub fn spkopn(fname: &str, ifname: &str, ncomch: i32) -> i32 {}
+}
+
+cspice_proc! {
+    /**
     Return the position of a target body relative to an observing body, optionally corrected for
     light time (planetary aberration) and stellar aberration.
     */

--- a/rust-spice/src/core/raw.rs
+++ b/rust-spice/src/core/raw.rs
@@ -347,6 +347,13 @@ cspice_proc! {
 
 cspice_proc! {
     /**
+    Close a SPK file opened for read or write.
+    */
+    pub fn spkcls(handle: i32) {}
+}
+
+cspice_proc! {
+    /**
     Create a new SPK file, returning the handle of the opened file
      */
     pub fn spkopn(fname: &str, ifname: &str, ncomch: i32) -> i32 {}

--- a/rust-spice/tests/core/mod.rs
+++ b/rust-spice/tests/core/mod.rs
@@ -247,7 +247,7 @@ fn open_test_spk(filepath: &str) -> i32 {
 #[test]
 #[serial]
 fn spkcls() {
-    let filepath = get_temp_filepath("spkclstestkernel.bsp");
+    let filepath = get_temp_filepath("/spkclstestkernel.bsp");
     let file = std::path::Path::new(&filepath);
     delete_if_exists(file);
 
@@ -263,7 +263,7 @@ fn spkcls() {
 #[test]
 #[serial]
 fn spkopn() {
-    let filepath = get_temp_filepath("spkopntestkernel.bsp");
+    let filepath = get_temp_filepath("/spkopntestkernel.bsp");
     let file = std::path::Path::new(&filepath);
     delete_if_exists(file);
 
@@ -279,7 +279,7 @@ fn spkopn() {
 #[test]
 #[serial]
 fn spkw09() {
-    let filepath = get_temp_filepath("spkw09testkernel.bsp");
+    let filepath = get_temp_filepath("/spkw09testkernel.bsp");
     let file = std::path::Path::new(&filepath);
     delete_if_exists(file);
 


### PR DESCRIPTION
Hey! First of all, thank you so much for this crate! I was pleasantly surprised to find such a nice wrapper for such a niche C library.

This PR adds everything necessary to construct basic SPK files (with type 9 segments) and corresponding tests. As the tests for each function require all other functions (you need to open a file and write to it to be able to close it, etc) and I wanted to make sure to only test one generated wrapper function in each test, I wrote quite a lot of code in rust-spice/core/tests/mod.rs. Of course, this could be simplified by testing all methods in one test, let me know if you'd prefer that. Some of the helper functions could be useful for testing other writer functions in the future though, so it's not all for just these three functions.

I only started learning Rust pretty recently and this is my first real PR, please don't hesitate to criticize me (even harshly) as I seriously want to get the hang of all this. I'd be happy to try and make any adjustments you request.

Have a nice day!