### PR TITLE
et2lst implemented

### DIFF
--- a/rust-spice/src/core/mod.rs
+++ b/rust-spice/src/core/mod.rs
@@ -37,6 +37,7 @@ CSPICE | **rust-spice** | Description
 [dskv02_c][dskv02_c link] | [`neat::dskv02`] | DSK, fetch type 2 vertex data
 [dskx02_c][dskx02_c link] | [`raw::dskx02`] | DSK, ray-surface intercept, type 2
 [dskz02_c][dskz02_c link] | [`raw::dskz02`] | DSK, fetch type 2 model size parameters
+[et2lst_c][et2lst_c link] | [`raw::et2lst`] | ET to local solar time given longitude
 [furnsh_c][furnsh_c link] | [`raw::furnsh`] | Furnish a program with SPICE kernels
 [gcpool_c][gcpool_c link] | *TODO*
 [gdpool_c][gdpool_c link] | [`raw::gdpool`] | Get d.p. values from the kernel pool
@@ -112,6 +113,7 @@ CSPICE | **rust-spice** | Description
 [dskv02_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/dskv02_c.html
 [dskx02_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/dskx02_c.html
 [dskz02_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/dskz02_c.html
+[et2lst_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/et2lst_c.html
 [furnsh_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/furnsh_c.html
 [gcpool_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/gcpool_c.html
 [gdpool_c link]: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/gdpool_c.html

--- a/rust-spice/src/core/neat.rs
+++ b/rust-spice/src/core/neat.rs
@@ -29,6 +29,29 @@ pub fn bodc2n(code: i32) -> (String, bool) {
 }
 
 /**
+Compute the local solar time for a given ephemeris epoch `et'
+for an object on the surface of a body at a specified longitude.
+
+See [`raw::et2lst`] for the raw interface.
+*/
+#[cfg_attr(any(feature = "lock", doc), impl_for(SpiceLock))]
+pub fn et2lst(
+    et: f64,
+    body_code: i32,
+    lon: f64,
+    lon_type: &str,
+) -> (i32, i32, i32, String, String) {
+    raw::et2lst(
+        et,
+        body_code,
+        lon,
+        lon_type,
+        MAX_LEN_OUT as i32,
+        MAX_LEN_OUT as i32,
+    )
+}
+
+/**
 This routine converts an input epoch represented in TDB seconds past the TDB epoch of J2000 to a
 character string formatted to the specifications of a user's format picture.
 

--- a/rust-spice/src/core/raw.rs
+++ b/rust-spice/src/core/raw.rs
@@ -92,6 +92,15 @@ cspice_proc! {
     pub fn bodn2c(name: &str) -> (i32, bool) {}
 }
 
+cspice_proc! {
+    /**
+     Compute the local solar time for a given ephemeris epoch `et'
+     for an object on the surface of a body at a specified longitude.
+     */
+    #[allow(clippy::too_many_arguments)]
+    pub fn et2lst(et: f64, body: i32, lon: f64, lon_type: &str, timlen: i32, ampmlen: i32) -> (i32, i32, i32, String, String) {}
+}
+
 /**
 Fetch from the kernel pool the double precision values of an item associated with a body.
 */
@@ -499,6 +508,7 @@ cspice_proc! {
     This routine supersedes srfxpt.
     */
     #[cfg_attr(any(feature = "lock", doc), impl_for(SpiceLock))]
+    #[allow(clippy::too_many_arguments)]
     pub fn sincpt(
         method:&str,
         target: &str,

--- a/rust-spice/tests/core/mod.rs
+++ b/rust-spice/tests/core/mod.rs
@@ -397,7 +397,10 @@ fn kdata() {
         "/Users/gregoireh/data/spice-kernels/hera/kernels/dsk/g_08438mm_lgt_obj_didb_0000n00000_v002.bds"
     );
     assert_eq!(filtyp, "DSK");
-    assert_eq!(source, "/Users/gregoireh/data/spice-kernels/hera/kernels/mk/hera_study_PO_EMA_2024.tm");
+    assert_eq!(
+        source,
+        "/Users/gregoireh/data/spice-kernels/hera/kernels/mk/hera_study_PO_EMA_2024.tm"
+    );
     assert!(handle.is_positive());
     assert_eq!(found, true);
 

--- a/rust-spice/tests/lib.rs
+++ b/rust-spice/tests/lib.rs
@@ -14,9 +14,11 @@ use std::ffi::CString;
 #[serial]
 fn test_c() {
     unsafe {
-        let kernel = CString::new("/Users/gregoireh/data/spice-kernels/hera/kernels/mk/hera_study_PO_EMA_2024.tm")
-            .unwrap()
-            .into_raw();
+        let kernel = CString::new(
+            "/Users/gregoireh/data/spice-kernels/hera/kernels/mk/hera_study_PO_EMA_2024.tm",
+        )
+        .unwrap()
+        .into_raw();
         spice::c::furnsh_c(kernel);
         spice::c::unload_c(kernel);
     }
@@ -123,8 +125,8 @@ pub mod lock_tests {
             c.join().unwrap();
         }
 
-        sl.lock()
-            .unwrap()
-            .unload("/Users/gregoireh/data/spice-kernels/hera/kernels/mk/hera_study_PO_EMA_2024.tm");
+        sl.lock().unwrap().unload(
+            "/Users/gregoireh/data/spice-kernels/hera/kernels/mk/hera_study_PO_EMA_2024.tm",
+        );
     }
 }


### PR DESCRIPTION
Following what appears to be the standard way of doing it, I implemented `et2lst`. This is kind of a test case to make sure I hit everything.

Note, I detected and fixed some warnings in the pre-hook tests, but could not get past unit testing due to some hard-coded paths.

```
check for added large files..........................................................Passed
check that executables have shebangs.............................(no files to check)Skipped
check for merge conflicts............................................................Passed
check toml.......................................................(no files to check)Skipped
check yaml.......................................................(no files to check)Skipped
fix end of files.....................................................................Passed
trim trailing whitespace.............................................................Passed
markdownlint.....................................................(no files to check)Skipped
Format YAML files................................................(no files to check)Skipped
fmt..................................................................................Passed
cargo check..........................................................................Passed
clippy...............................................................................Passed
Compile and execute unit and integration tests for all targets.......................Failed
- hook id: execute-tests
- exit code: 1

   Compiling rust-spice-derive v0.7.6 (/home/hook/FB/ws/rust-spice/rust-spice-derive)
   Compiling rust-spice v0.7.8 (/home/hook/FB/ws/rust-spice/rust-spice)
    Finished test [unoptimized + debuginfo] target(s) in 0.72s
     Running unittests src/lib.rs (target/debug/deps/spice-c93f4cd88b5e353f)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/lib.rs (target/debug/deps/lib-a6ca4379499362e1)

running 20 tests
 
================================================================================
 
Toolkit version: N0067
 
SPICE(NOSUCHFILE) --
 
The attempt to load
"/Users/gregoireh/data/spice-kernels/hera/kernels/mk/hera_study_PO_EMA_2024.tm"
by the routine FURNSH failed. It could not be located.
 
A traceback follows.  The name of the highest level module is first.
furnsh_c --> FURNSH --> ZZLDKER
 
Oh, by the way:  The SPICELIB error handling actions are USER-TAILORABLE.  You
can choose whether the Toolkit aborts or continues when errors occur, which
error messages to output, and where to send the output.  Please read the ERROR
"Required Reading" file, or see the routines ERRACT, ERRDEV, and ERRPRT.
 
================================================================================
error: test failed, to rerun pass `-p rust-spice --test lib`

Caused by:
  process didn't exit successfully: `/home/hook/FB/ws/rust-spice/target/debug/deps/lib-a6ca4379499362e1` (exit status: 1)
note: test exited abnormally; to see the full output pass --nocapture to the harness.

```